### PR TITLE
Add new route url styles for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Webhook relay for **University Of Helsinki (The National Library Of Finland)**
 
+## Working hook url schemas:
+
+* `https://<baseUrl>/<project>/<buildConfig>/<secret>`
+* `https://<baseUrl>/namespaces/<project>/buildconfigs/<buildConfig>/webhooks/<secret>/generic`
+* `https://<baseUrl>/apis/build.openshift.io/v1/namespaces/<project>/buildconfigs/<buildConfig>/webhooks/<secret>/generic`
+
 ## Envs
 ### Generic envs
 | Name                  | Description                         | default or e.g.                                          |

--- a/src/routes/webhookRoute.js
+++ b/src/routes/webhookRoute.js
@@ -19,7 +19,6 @@ export default function (openshiftWebhookUrl) { // eslint-disable-line no-unused
     const data = req.body;
     logger.debug('data: ', data);
     const triggerUrl = `${openshiftWebhookUrl}/${project}/buildconfigs/${buildConfig}/webhooks/${id}/generic`;
-    logger.debug(triggerUrl);
     fetch(
       triggerUrl,
       {

--- a/src/routes/webhookRoute.js
+++ b/src/routes/webhookRoute.js
@@ -9,6 +9,7 @@ export default function (openshiftWebhookUrl) { // eslint-disable-line no-unused
 
   return new Router()
     .post('/:project/:buildConfig/:id', bodyParser.json(), handleHook)
+    .post('/namespaces/:project/buildconfigs/:buildConfig/webhooks/:id/generic', bodyParser.json(), handleHook)
     .use(handleError);
 
   function handleHook(req, res) {

--- a/src/routes/webhookRoute.js
+++ b/src/routes/webhookRoute.js
@@ -10,6 +10,7 @@ export default function (openshiftWebhookUrl) { // eslint-disable-line no-unused
   return new Router()
     .post('/:project/:buildConfig/:id', bodyParser.json(), handleHook)
     .post('/namespaces/:project/buildconfigs/:buildConfig/webhooks/:id/generic', bodyParser.json(), handleHook)
+    .post('/apis/build.openshift.io/v1/namespaces/:project/buildconfigs/:buildConfig/webhooks/:id/generic', bodyParser.json(), handleHook)
     .use(handleError);
 
   function handleHook(req, res) {


### PR DESCRIPTION
Working url schemas:

`https://<baseUrl>/<project>/<buildConfig>/<secret>`

`https://<baseUrl>/namespaces/<project>/buildconfigs/<buildConfig>/webhooks/<secret>/generic`

`https://<baseUrl>/apis/build.openshift.io/v1/namespaces/<project>/buildconfigs/<buildConfig>/webhooks/<secret>/generic`